### PR TITLE
README: add 2 sections; overall improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
-mu-wizard
---------------------------------------------------------------------------------
-
+## mu-wizard
 Shell script to auto-configure email accounts for `mu4e` similar in function to
 mutt-wizard. It uses `isync` to synchronize mail accounts, `msmtp` to send mail
 and creates individual Lisp profiles for each account. It is still WIP.
 
-
-Dependencies
---------------------------------------------------------------------------------
-
+## Dependencies
 * `isync` (for offline mail storage)
 * `mu` (or maildir-utils depending on your distribution)
 * `msmtp` (for sending mails)
 * Password manager (`pass`, `pash`, and `pm` is supported)
 
+## Installation
+In order to install mu-wizard, clone this repository and build mu-wizard.
 
-
-Installation and Configuration
---------------------------------------------------------------------------------
-
-In order to install clone this repository and run the following command.
-
+    git clone https://github.com/cemkeylan/mu-wizard.git
+    cd mu-wizard
     make install
 
+Users of Arch Linux based distributions can install mu-wizard through the AUR package [mu-wizard-git](https://aur.archlinux.org/packages/mu-wizard-git/):
+
+    yay -S mu-wizard-git
+
+## Usage
+The wizard is run with `muw`. The options bellow are availabe for usage with `muw`:
+- `muw`: Show usage help.
+- `muw a`: **Add** and aoutoconfigure an email address.
+- `muw d`: Pick an account to **delete**.
+- `muw l`: **List** configured accounts.
+- `muw p`: **Purge** all configuration.
+- `muw s`: See your **share** directory: command not found.
+
+## Emacs Configuration
 Emacs will not be loading the configurations, you will need to set it manually.
 In your init file, you may choose to load the configuration in the following
 ways.
@@ -42,28 +49,20 @@ ways.
   :load-path "~/.config/mu4e")
 ```
 
-
-`Domains.csv` file
---------------------------------------------------------------------------------
-
+## `Domains.csv` file
 `mu-wizard` doesn't come with a predefined `domains.csv` file, but it can use
 one if it is found on `/usr/share/mu-wizard/domains.csv`. `mu-wizard` also saves
 the domain information that you use when creating an account on your
 configuration directory, so you don't have to retype every detail when creating
 a second account with the same domain.
 
-
-Overrides
---------------------------------------------------------------------------------
-
+## Overrides
 Domain-level overrides are possible by adding a shell file to either the share
 directory (`/usr/local/share/mu-wizard/overrides`) or the user configuration
 directory (`~/.config/mu4e/overrides`). See `overrides/protonmail.com` for an
 example override. You can run `muw share` to learn your share directory.
 
-
 ### Protonmail users
-
 `mu-wizard` supports protonmail. If you are using one of the default domains,
 you don't have to do anything. If you are an alternative domain, you can link
 the protonmail.com override to your personal domain. Here is an example:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The wizard is run with `muw`. The options bellow are availabe for usage with `mu
 - `muw d`: Pick an account to **delete**.
 - `muw l`: **List** configured accounts.
 - `muw p`: **Purge** all configuration.
-- `muw s`: See your **share** directory: command not found.
+- `muw s`: See your **share** directory.
 
 ## Emacs Configuration
 Emacs will not be loading the configurations, you will need to set it manually.


### PR DESCRIPTION
- Separate the section "Installation and Configuration" in 2 sections: "Installation" and "Emacs Configuration". 
- Add further instructions for installation.
- Add "Usage" section in between. 
- Normalize markdown headings.